### PR TITLE
Create PH Paper site

### DIFF
--- a/src/components/CustomStyles.astro
+++ b/src/components/CustomStyles.astro
@@ -25,16 +25,16 @@ import '@fontsource-variable/inter';
     --aw-font-serif: 'Inter Variable';
     --aw-font-heading: 'Inter Variable';
 
-    --aw-color-primary: rgb(1 97 239);
-    --aw-color-secondary: rgb(1 84 207);
-    --aw-color-accent: rgb(109 40 217);
+    --aw-color-primary: rgb(255 255 255);
+    --aw-color-secondary: rgb(235 235 235);
+    --aw-color-accent: rgb(255 255 255);
 
-    --aw-color-text-heading: rgb(0 0 0);
-    --aw-color-text-default: rgb(16 16 16);
-    --aw-color-text-muted: rgb(16 16 16 / 66%);
-    --aw-color-bg-page: rgb(255 255 255);
+    --aw-color-text-heading: rgb(255 255 255);
+    --aw-color-text-default: rgb(255 255 255);
+    --aw-color-text-muted: rgb(255 255 255 / 66%);
+    --aw-color-bg-page: rgb(0 150 214);
 
-    --aw-color-bg-page-dark: rgb(3 6 32);
+    --aw-color-bg-page-dark: rgb(0 80 150);
 
     ::selection {
       background-color: lavender;
@@ -46,14 +46,14 @@ import '@fontsource-variable/inter';
     --aw-font-serif: 'Inter Variable';
     --aw-font-heading: 'Inter Variable';
 
-    --aw-color-primary: rgb(1 97 239);
-    --aw-color-secondary: rgb(1 84 207);
-    --aw-color-accent: rgb(109 40 217);
+    --aw-color-primary: rgb(255 255 255);
+    --aw-color-secondary: rgb(235 235 235);
+    --aw-color-accent: rgb(255 255 255);
 
-    --aw-color-text-heading: rgb(247, 248, 248);
-    --aw-color-text-default: rgb(229 236 246);
-    --aw-color-text-muted: rgb(229 236 246 / 66%);
-    --aw-color-bg-page: rgb(3 6 32);
+    --aw-color-text-heading: rgb(255 255 255);
+    --aw-color-text-default: rgb(255 255 255);
+    --aw-color-text-muted: rgb(255 255 255 / 66%);
+    --aw-color-bg-page: rgb(0 80 150);
 
     ::selection {
       background-color: black;

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -5,5 +5,7 @@ import { SITE } from 'astrowind:config';
 <span
   class="self-center ml-2 rtl:ml-0 rtl:mr-2 text-2xl md:text-xl font-bold text-gray-900 whitespace-nowrap dark:text-white"
 >
-  🚀 {SITE?.name}
+  <!-- Replace the text below with your logo image if desired -->
+  <!-- <img src="/path/to/logo.png" alt="PH Paper logo" class="h-8 w-auto" /> -->
+  {SITE?.name}
 </span>

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,6 +1,6 @@
 site:
-  name: Satispie
-  site: 'https://satispie.example.com'
+  name: PH Paper
+  site: 'https://phpaper.example.com'
   base: '/'
   trailingSlash: false
 
@@ -9,14 +9,14 @@ site:
 # Default SEO metadata
 metadata:
   title:
-    default: Satispie
-    template: '%s — Satispie'
-  description: "Delicious frozen pies delivered straight from our ovens to your freezer."
+    default: PH Paper
+    template: '%s — PH Paper'
+  description: "Science Driving Efficiency with innovative pH testing products."
   robots:
     index: true
     follow: true
   openGraph:
-    site_name: Satispie
+    site_name: PH Paper
     images:
       - url: '~/assets/images/default.png'
         width: 1200

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -13,7 +13,7 @@ export const headerData = {
 export const footerData = {
   links: [
     {
-      title: 'Satispie',
+      title: 'PH Paper',
       links: [
         { text: 'Home', href: getPermalink('/') },
         { text: 'Products', href: getPermalink('/products') },
@@ -31,5 +31,5 @@ export const footerData = {
     { ariaLabel: 'Instagram', icon: 'tabler:brand-instagram', href: '#' },
     { ariaLabel: 'Facebook', icon: 'tabler:brand-facebook', href: '#' },
   ],
-  footNote: '© Satispie',
+  footNote: '© PH Paper',
 };

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -8,21 +8,21 @@ const metadata = { title: 'About Us' };
 
 <Layout metadata={metadata}>
   <Hero2
-    tagline="About Satispie"
-    title="Baking Smiles Since 1998"
-    subtitle="Our family-owned bakery crafts frozen pies with love and tradition."
+    tagline="About PH Paper"
+    title="Science Driving Efficiency"
+    subtitle="Delivering accurate pH measurement tools to laboratories worldwide."
     image={{
-      src: 'https://images.unsplash.com/photo-1518131671429-5e1640a8fd8c?auto=format&fit=crop&w=1200&q=80',
-      alt: 'Bakers preparing pies',
+      src: 'https://images.unsplash.com/photo-1581092334015-3a06aa3f1c9c?auto=format&fit=crop&w=1200&q=80',
+      alt: 'Scientist working in lab',
     }}
   />
 
   <Content
     title="Our Mission"
     items={[
-      { title: 'Quality', description: 'We select the best ingredients for unforgettable flavor.' },
-      { title: 'Tradition', description: 'Recipes passed down through generations of pie lovers.' },
-      { title: 'Happiness', description: 'We believe every slice should bring joy.' },
+      { title: 'Innovation', description: 'Develop products that simplify your workflow.' },
+      { title: 'Precision', description: 'Provide reliable results that you can trust.' },
+      { title: 'Support', description: 'Back every purchase with expert assistance.' },
     ]}
   />
 </Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -12,7 +12,7 @@ const metadata = {
 <Layout metadata={metadata}>
   <!-- HeroText Widget ******************* -->
 
-  <HeroText tagline="Contact" title="Let's Connect!" />
+  <HeroText tagline="Contact PH Paper" title="Let's Connect!" />
 
   <ContactUs
     id="form"
@@ -47,17 +47,17 @@ const metadata = {
     items={[
       {
         title: 'General support',
-        description: `Chat with us for inquiries related to account management, website navigation, payment issues, accessing purchased templates or general questions about the website's functionality.`,
+        description: `Questions about using our products or choosing the right solution for your work.`,
       },
       {
         title: 'Contact sales',
         description:
-          'Chat with us for questions about purchases, customization options, licensing for commercial use, inquiries about specific template, etc.',
+          'Discuss bulk orders, pricing details or distribution opportunities.',
       },
       {
         title: 'Technical support',
         description:
-          'Chat with us when facing issues like template installation, problems editing difficulties, compatibility issues with software or download errors, or other technical challenges related to using the templates.',
+          'Get help with calibration, maintenance or troubleshooting equipment.',
       },
       {
         title: 'Phone',
@@ -66,7 +66,7 @@ const metadata = {
       },
       {
         title: 'Email',
-        description: 'contact@support.com',
+        description: 'info@phpaper.example.com',
         icon: 'tabler:mail',
       },
       {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,47 +5,47 @@ import Features from '~/components/widgets/Features.astro';
 import CallToAction from '~/components/widgets/CallToAction.astro';
 
 const metadata = {
-  title: 'Satispie — Frozen Pies',
+  title: 'PH Paper — Science Driving Efficiency',
 };
 ---
 
 <Layout metadata={metadata}>
   <Hero2
-    tagline="Welcome to Satispie"
-    title="Irresistible Frozen Pies"
-    subtitle="Hand crafted pies delivered right to your freezer."
+    tagline="Science Driving Efficiency"
+    title="Precision pH Measurement Solutions"
+    subtitle="Innovative testing tools for laboratories and industry."
     actions={[{ variant: 'primary', text: 'Shop Now', href: '/products' }]}
     image={{
-      src: 'https://images.unsplash.com/photo-1601050690188-2f26f1b74668?auto=format&fit=crop&w=1200&q=80',
-      alt: 'Freshly baked pie',
+      src: 'https://images.unsplash.com/photo-1521791136064-7986c2920216?auto=format&fit=crop&w=1200&q=80',
+      alt: 'Lab technician using pH meter',
     }}
   />
 
   <Features
     id="features"
-    title="Why Choose Satispie?"
+    title="Why Choose PH Paper?"
     items={[
       {
-        title: 'Quality Ingredients',
-        description: 'Only the freshest fruit and finest pastry for a true homemade taste.',
-        icon: 'tabler:leaf',
+        title: 'Accurate Results',
+        description: 'Engineered for reliable pH readings in every test.',
+        icon: 'tabler:gauge',
       },
       {
-        title: 'Frozen for Convenience',
-        description: 'Keep a pie in your freezer and enjoy whenever you like.',
-        icon: 'tabler:snowflake',
+        title: 'Easy to Use',
+        description: 'Intuitive products designed for quick measurements.',
+        icon: 'tabler:click',
       },
       {
-        title: 'Nationwide Delivery',
-        description: 'We ship anywhere so you can enjoy Satispie wherever you are.',
-        icon: 'tabler:truck',
+        title: 'Expert Support',
+        description: 'Our team is ready to help you get the best from our tools.',
+        icon: 'tabler:lifebuoy',
       },
     ]}
   />
 
   <CallToAction
-    title="Ready for dessert?"
-    subtitle="Browse our selection of mouth‑watering pies."
+    title="Need precise measurements?"
+    subtitle="Discover our complete range of pH testing supplies."
     actions={[{ variant: 'primary', text: 'View Products', href: '/products' }]}
   />
 </Layout>

--- a/src/pages/products.astro
+++ b/src/pages/products.astro
@@ -8,33 +8,33 @@ const metadata = { title: 'Our Products' };
 
 <Layout metadata={metadata}>
   <Hero2
-    tagline="Our Pies"
-    title="Choose Your Favorite Flavor"
-    subtitle="From classic apple to rich chocolate, there's a Satispie for everyone."
+    tagline="Our Products"
+    title="Reliable pH Testing Supplies"
+    subtitle="Find the right tools for every application."
     image={{
-      src: 'https://images.unsplash.com/photo-1603189616795-d686f1dbc993?auto=format&fit=crop&w=1200&q=80',
-      alt: 'Assorted pies',
+      src: 'https://images.unsplash.com/photo-1581092795362-0b2cc249743b?auto=format&fit=crop&w=1200&q=80',
+      alt: 'Laboratory pH equipment',
     }}
   />
 
   <Features3
-    title="Flavors"
+    title="Catalog"
     columns={3}
     items={[
       {
-        title: 'Apple Pie',
-        description: 'Sweet apples baked in a flaky crust.',
-        icon: 'tabler:apple',
+        title: 'pH Test Strips',
+        description: 'Quick and convenient testing for a wide range of samples.',
+        icon: 'tabler:list-details',
       },
       {
-        title: 'Cherry Pie',
-        description: 'Tart cherries with just the right amount of sweetness.',
-        icon: 'tabler:cherry',
+        title: 'Digital pH Meters',
+        description: 'High precision instruments for accurate measurements.',
+        icon: 'tabler:device-laptop',
       },
       {
-        title: 'Pumpkin Pie',
-        description: 'Creamy pumpkin spice perfect for the holidays.',
-        icon: 'tabler:pumpkin-scissors',
+        title: 'Calibration Solutions',
+        description: 'Maintain consistency with certified buffer standards.',
+        icon: 'tabler:flask',
       },
     ]}
   />


### PR DESCRIPTION
## Summary
- brand rename to PH Paper with tagline "Science Driving Efficiency"
- update colors to reversed HP style
- rewrite content for home, about, products, and contact pages
- placeholder slot for custom logo

## Testing
- `npm run check` *(fails: astro not found)*